### PR TITLE
Allow passing options to generate_html

### DIFF
--- a/src/PlutoPDF.jl
+++ b/src/PlutoPDF.jl
@@ -43,6 +43,10 @@ const screenshot_default_options = (
     scale=2,
 )
 
+const generate_html_default_options = (
+    binder_url_js="undefined",
+)
+
 """
 The same as `pluto_to_pdf`, but the first argument is a path to an HTML file or a URL (to a Pluto notebook hosted online).
 """
@@ -109,6 +113,7 @@ function pluto_to_pdf(
     notebook_path::AbstractString,
     output_path::Union{AbstractString,Nothing}=nothing,
     screenshot_dir_path::Union{AbstractString,Nothing}=nothing;
+    generate_html_options=generate_html_default_options,
     kwargs...
 )
     c = Pluto.Configuration.from_flat_kwargs(;
@@ -118,7 +123,7 @@ function pluto_to_pdf(
     session = Pluto.ServerSession(;options=c)
     @info "Running notebook..."
     notebook = Pluto.SessionActions.open(session, notebook_path; run_async=false)
-    html_contents = Pluto.generate_html(notebook; binder_url_js="undefined")
+    html_contents = Pluto.generate_html(notebook; generate_html_options...)
     Pluto.SessionActions.shutdown(session, notebook)
 
     filename = tempname() * ".html"

--- a/src/PlutoPDF.jl
+++ b/src/PlutoPDF.jl
@@ -88,6 +88,7 @@ end
 """
 ```julia
 pluto_to_pdf(notebook_path::String[, output_pdf_path::String, screenshot_dir_path::String];
+    generate_html_options=(;),
     options=default_options,
     screenshot_options=screenshot_default_options,
     open::Bool=true,
@@ -98,6 +99,7 @@ pluto_to_pdf(notebook_path::String[, output_pdf_path::String, screenshot_dir_pat
 Run a notebook, generate an Export HTML and then print it to a PDF file! If a `screenshot_dir_path` is provided, then PlutoPDF will also take a screenshot of each cell and save it to the directory.
 
 # Options
+The `generate_html_options` keyword argument can be a named tuple to configure the HTML generation. See `Pluto.generate_html` for the list of possible options.
 The `options` keyword argument can be a named tuple to configure the PDF export. The possible options can be seen in the [docs for `puppeteer.PDFOptions`](https://pptr.dev/api/puppeteer.pdfoptions). You don't need to specify all options, for example: `options=(format="A5",)` will work.
 
 The `screenshot_options` keyword argument can be a named tuple to configure the generation of cell screenshots. Available options:

--- a/src/PlutoPDF.jl
+++ b/src/PlutoPDF.jl
@@ -43,10 +43,6 @@ const screenshot_default_options = (
     scale=2,
 )
 
-const generate_html_default_options = (
-    binder_url_js="undefined",
-)
-
 """
 The same as `pluto_to_pdf`, but the first argument is a path to an HTML file or a URL (to a Pluto notebook hosted online).
 """
@@ -113,7 +109,7 @@ function pluto_to_pdf(
     notebook_path::AbstractString,
     output_path::Union{AbstractString,Nothing}=nothing,
     screenshot_dir_path::Union{AbstractString,Nothing}=nothing;
-    generate_html_options=generate_html_default_options,
+    generate_html_options=(;),
     kwargs...
 )
     c = Pluto.Configuration.from_flat_kwargs(;
@@ -123,7 +119,7 @@ function pluto_to_pdf(
     session = Pluto.ServerSession(;options=c)
     @info "Running notebook..."
     notebook = Pluto.SessionActions.open(session, notebook_path; run_async=false)
-    html_contents = Pluto.generate_html(notebook; generate_html_options...)
+    html_contents = Pluto.generate_html(notebook; binder_url_js="undefined", generate_html_options...)
     Pluto.SessionActions.shutdown(session, notebook)
 
     filename = tempname() * ".html"


### PR DESCRIPTION
Following https://github.com/fonsp/Pluto.jl/pull/3156#issuecomment-2740401602, it would allow enabling presentation mode with
```julia
enable_present = """`
<script>
window.present()
</script>
`"""
PlutoPDF.pluto_to_pdf(file; generate_html_options = (; preamble_html_js = enable_present, PlutoPDF.generate_html_default_options...))
```